### PR TITLE
docs: spec do módulo report-module (TASK-04)

### DIFF
--- a/.kiro/specs/report-module/.config.kiro
+++ b/.kiro/specs/report-module/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "0822ac57-839b-4d86-a43d-2fe41822372c", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/report-module/design.md
+++ b/.kiro/specs/report-module/design.md
@@ -1,0 +1,243 @@
+# Design Técnico: report-module
+
+## Visão Geral
+
+O `report.py` é um módulo utilitário do KiroSonar responsável por persistir o relatório gerado pela LLM como arquivo Markdown na pasta `relatorios/`. Ele é completamente independente dos demais módulos — recebe dados prontos do orquestrador (`cli.py`) e não consome nenhuma outra dependência interna do projeto.
+
+O módulo expõe duas funções públicas:
+
+- `generate_report_name(file_path)` — gera um nome de arquivo único com base no caminho do arquivo analisado e um timestamp.
+- `save_report(content, file_path)` — orquestra a criação do diretório, a escrita do arquivo e o retorno do caminho absoluto.
+
+Restrições técnicas:
+- Apenas Standard Library Python (`os`, `datetime`)
+- Python 3.11+
+- PEP 8, Type Hinting obrigatório, Docstrings em todas as funções
+- Encoding UTF-8 em todas as operações de escrita
+
+---
+
+## Arquitetura
+
+O módulo segue uma arquitetura de funções puras e procedimentos simples, sem estado global nem classes. O fluxo de execução é linear:
+
+```mermaid
+sequenceDiagram
+    participant CLI as cli.py
+    participant R as report.py
+    participant FS as Sistema de Arquivos
+
+    CLI->>R: save_report(content, file_path)
+    R->>R: generate_report_name(file_path)
+    Note over R: safe_name = substituir /\. por _
+    Note over R: timestamp = datetime.now().strftime(...)
+    R->>FS: os.makedirs("relatorios/", exist_ok=True)
+    R->>FS: open(report_name, "w", encoding="utf-8")
+    FS-->>R: arquivo criado
+    R->>R: os.path.abspath(report_name)
+    R-->>CLI: caminho absoluto do relatório
+```
+
+### Decisões de Design
+
+1. **Sem estado global**: as funções são stateless — cada chamada é independente. Isso facilita testes e evita efeitos colaterais.
+2. **`exist_ok=True` no makedirs**: garante idempotência na criação do diretório, eliminando a necessidade de verificação prévia.
+3. **Timestamp no nome do arquivo**: garante unicidade mesmo para o mesmo `file_path` chamado em sequência rápida (resolução de segundos).
+4. **Retorno do caminho absoluto**: desacopla o chamador de qualquer suposição sobre o diretório de trabalho atual.
+5. **`print()` para feedback**: o módulo imprime o caminho salvo em `stdout` conforme Requisito 6, mantendo o feedback simples sem dependência de logging.
+
+---
+
+## Componentes e Interfaces
+
+### `generate_report_name(file_path: str) -> str`
+
+Responsabilidade: produzir um nome de arquivo determinístico (dado o instante de chamada) e seguro para o sistema de arquivos.
+
+```
+Entrada : file_path  → str  (ex: "src/app.py", "backend\src\main.py")
+Saída   : str              (ex: "relatorios/src_app_py_20260318_173000.md")
+```
+
+Algoritmo:
+1. Substituir `os.sep`, `/` e `.` por `_` → `safe_name`
+2. Capturar `datetime.now().strftime("%Y%m%d_%H%M%S")` → `timestamp`
+3. Retornar `os.path.join("relatorios", f"{safe_name}_{timestamp}.md")`
+
+### `save_report(content: str, file_path: str) -> str`
+
+Responsabilidade: orquestrar a persistência do relatório e retornar o caminho absoluto.
+
+```
+Entrada : content    → str  (Markdown retornado pela LLM)
+          file_path  → str  (caminho do arquivo analisado)
+Saída   : str              (caminho absoluto do arquivo salvo)
+```
+
+Algoritmo:
+1. Chamar `generate_report_name(file_path)` → `report_name`
+2. `os.makedirs(os.path.dirname(report_name), exist_ok=True)`
+3. Abrir `report_name` em modo escrita com `encoding="utf-8"`
+4. Escrever `content`
+5. Imprimir caminho absoluto em `stdout`
+6. Retornar `os.path.abspath(report_name)`
+
+---
+
+## Modelos de Dados
+
+O módulo não define classes nem estruturas de dados próprias. Os tipos envolvidos são primitivos Python:
+
+| Símbolo | Tipo | Descrição |
+|---|---|---|
+| `file_path` | `str` | Caminho do arquivo de código-fonte analisado (ex: `src/app.py`) |
+| `safe_name` | `str` | `file_path` com `/`, `\` e `.` substituídos por `_` |
+| `timestamp` | `str` | String `YYYYMMDD_HHMMSS` gerada no momento da chamada |
+| `report_name` | `str` | Caminho relativo do relatório: `relatorios/<safe_name>_<timestamp>.md` |
+| `content` | `str` | Conteúdo Markdown do relatório gerado pela LLM |
+| `MOCK_CONTENT` | `str` | Constante Markdown para testes independentes da LLM |
+
+### Formato do nome do arquivo
+
+```
+relatorios/<safe_name>_<timestamp>.md
+
+Exemplos:
+  file_path = "src/app.py"       → relatorios/src_app_py_20260318_173000.md
+  file_path = "backend/src/x.py" → relatorios/backend_src_x_py_20260318_173001.md
+  file_path = "main.py"          → relatorios/main_py_20260318_173002.md
+```
+
+
+---
+
+## Propriedades de Corretude
+
+*Uma propriedade é uma característica ou comportamento que deve ser verdadeiro em todas as execuções válidas de um sistema — essencialmente, uma declaração formal sobre o que o sistema deve fazer. Propriedades servem como ponte entre especificações legíveis por humanos e garantias de corretude verificáveis por máquina.*
+
+### Propriedade 1: Formato do nome gerado
+
+*Para qualquer* `file_path` válido, o resultado de `generate_report_name(file_path)` deve começar com `"relatorios/"`, terminar com `".md"` e conter uma substring que corresponda ao padrão `\d{8}_\d{6}` (timestamp `YYYYMMDD_HHMMSS`).
+
+**Validates: Requirements 1.1, 1.4**
+
+---
+
+### Propriedade 2: Sanitização do safe_name
+
+*Para qualquer* string `file_path`, o nome gerado por `generate_report_name(file_path)` não deve conter os caracteres `/`, `\` nem `.` na parte do `safe_name` (antes do timestamp e da extensão `.md`).
+
+**Validates: Requirements 1.2, 1.3**
+
+---
+
+### Propriedade 3: Diretório criado automaticamente
+
+*Para qualquer* `content` e `file_path`, após a chamada de `save_report(content, file_path)` em um diretório temporário onde `relatorios/` não existia, o diretório `relatorios/` deve existir no sistema de arquivos.
+
+**Validates: Requirements 2.1, 2.2**
+
+---
+
+### Propriedade 4: Round-trip de conteúdo com suporte a Unicode
+
+*Para qualquer* string `content` (incluindo strings com acentos, cedilha e outros caracteres Unicode), após `save_report(content, file_path)`, a leitura do arquivo salvo com `encoding="utf-8"` deve retornar exatamente o mesmo `content` original.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+---
+
+### Propriedade 5: Retorno é caminho absoluto existente
+
+*Para qualquer* `content` e `file_path`, o valor retornado por `save_report(content, file_path)` deve ser um caminho absoluto (`os.path.isabs` retorna `True`) que aponta para um arquivo existente no sistema de arquivos (`os.path.exists` retorna `True`).
+
+**Validates: Requirements 4.1, 4.2**
+
+---
+
+### Propriedade 6: file_paths distintos geram nomes distintos
+
+*Para quaisquer* dois `file_path` distintos (`fp1 != fp2`), `generate_report_name(fp1)` e `generate_report_name(fp2)` devem retornar nomes de arquivo diferentes (desconsiderando o timestamp, o `safe_name` já os diferencia).
+
+**Validates: Requirements 5.1**
+
+---
+
+### Propriedade 7: stdout contém o caminho absoluto
+
+*Para qualquer* `content` e `file_path`, após `save_report(content, file_path)`, a saída padrão (`stdout`) deve conter o caminho absoluto do arquivo salvo.
+
+**Validates: Requirements 6.1**
+
+---
+
+## Tratamento de Erros
+
+O módulo opera com Standard Library e não lança exceções próprias. Os cenários de erro relevantes são:
+
+| Cenário | Comportamento esperado |
+|---|---|
+| `file_path` é string vazia `""` | `safe_name` será `""`, gerando `relatorios/__<timestamp>.md` — comportamento definido, sem exceção |
+| Sem permissão de escrita no diretório | `PermissionError` propagado naturalmente pelo `open()` — não é tratado no módulo |
+| `content` é string vazia `""` | Arquivo `.md` criado com conteúdo vazio — comportamento válido |
+| `relatorios/` já existe | `exist_ok=True` garante que nenhuma exceção é lançada (Requisito 2.2) |
+
+A estratégia de não capturar exceções de I/O é intencional: erros de permissão ou disco cheio devem ser propagados ao orquestrador (`cli.py`), que tem o contexto para exibir mensagens de erro ao usuário.
+
+---
+
+## Estratégia de Testes
+
+### Abordagem Dual
+
+Os testes do `report-module` combinam testes unitários (exemplos específicos e casos de borda) com testes baseados em propriedades (cobertura universal de inputs).
+
+**Arquivo de testes:** `backend/tests/test_report.py`
+
+### Testes Unitários
+
+Focados em exemplos concretos e casos de borda:
+
+- Exemplo: `generate_report_name("src/app.py")` retorna string no formato esperado
+- Exemplo: `save_report()` chamado duas vezes com o mesmo `file_path` em instantes distintos (mock de `datetime`) gera nomes diferentes (Requisito 1.5, 5.2)
+- Edge case: `save_report()` chamado com `relatorios/` já existente não lança exceção (Requisito 2.2)
+- Edge case: `content` com string vazia cria arquivo vazio sem erro
+- Integração: `save_report()` com `MOCK_CONTENT` sem importar nenhum outro módulo do KiroSonar
+
+### Testes Baseados em Propriedades
+
+Biblioteca: **Hypothesis** (`pip install hypothesis`)
+
+Cada propriedade do design deve ser implementada como um único teste de propriedade com mínimo de 100 iterações (padrão do Hypothesis).
+
+Formato de tag obrigatório em cada teste:
+
+```
+# Feature: report-module, Property <N>: <texto da propriedade>
+```
+
+| Propriedade | Teste | Tag |
+|---|---|---|
+| P1: Formato do nome gerado | `@given(st.text(min_size=1))` verifica prefixo, sufixo e regex do timestamp | `Feature: report-module, Property 1` |
+| P2: Sanitização do safe_name | `@given(st.text())` verifica ausência de `/`, `\`, `.` no safe_name | `Feature: report-module, Property 2` |
+| P3: Diretório criado automaticamente | `@given(st.text(), st.text(min_size=1))` em `tmp_path` verifica existência de `relatorios/` | `Feature: report-module, Property 3` |
+| P4: Round-trip de conteúdo com Unicode | `@given(st.text())` escreve e lê o arquivo, compara conteúdo | `Feature: report-module, Property 4` |
+| P5: Retorno é caminho absoluto existente | `@given(st.text(), st.text(min_size=1))` verifica `isabs` e `exists` | `Feature: report-module, Property 5` |
+| P6: file_paths distintos geram nomes distintos | `@given(st.text(), st.text())` com `assume(fp1 != fp2)` verifica nomes diferentes | `Feature: report-module, Property 6` |
+| P7: stdout contém caminho absoluto | `@given(st.text(), st.text(min_size=1))` captura stdout e verifica presença do caminho | `Feature: report-module, Property 7` |
+
+### Configuração do Hypothesis
+
+```python
+from hypothesis import given, settings, strategies as st
+
+@settings(max_examples=100)
+@given(st.text(min_size=1))
+def test_property_1_formato_nome(file_path: str) -> None:
+    # Feature: report-module, Property 1: Formato do nome gerado
+    ...
+```
+
+### Isolamento
+
+Todos os testes que envolvem I/O devem usar `tmp_path` (fixture do pytest) para garantir isolamento do sistema de arquivos real. O módulo não requer mock de dependências externas além de `datetime.now()` para testes de unicidade temporal.

--- a/.kiro/specs/report-module/requirements.md
+++ b/.kiro/specs/report-module/requirements.md
@@ -1,0 +1,88 @@
+# Documento de Requisitos
+
+## Introdução
+
+O módulo `report.py` é responsável por persistir o relatório gerado pela LLM como arquivo Markdown na pasta `relatorios/` do projeto analisado. Ele recebe o conteúdo textual da análise e o caminho do arquivo original analisado, gerando um nome de arquivo único com timestamp e salvando o conteúdo com encoding UTF-8. O módulo é independente dos demais módulos do KiroSonar e pode ser testado isoladamente com conteúdo mock.
+
+## Glossário
+
+- **Report_Module**: O módulo `src/report.py` responsável por persistir relatórios em Markdown.
+- **Report_Name_Generator**: A função `generate_report_name()` que produz o nome do arquivo de relatório.
+- **Report_Saver**: A função `save_report()` que orquestra a criação da pasta e a escrita do arquivo.
+- **file_path**: Caminho do arquivo de código-fonte original que foi analisado pela LLM (ex: `src/app.py`).
+- **safe_name**: Versão sanitizada do `file_path` com `/`, `\` e `.` substituídos por `_`.
+- **timestamp**: String no formato `YYYYMMDD_HHMMSS` gerada no momento da chamada de `save_report()`.
+- **relatorios/**: Diretório de destino dos relatórios, criado automaticamente na raiz do projeto em execução.
+- **MOCK_CONTENT**: String Markdown fixa usada para testes independentes da LLM.
+
+---
+
+## Requisitos
+
+### Requisito 1: Geração do Nome do Relatório
+
+**User Story:** Como desenvolvedor, quero que o nome do arquivo de relatório seja único e identificável, para que eu consiga rastrear qual arquivo foi analisado e quando.
+
+#### Critérios de Aceite
+
+1. WHEN `generate_report_name(file_path)` é chamado com um `file_path` válido, THE `Report_Name_Generator` SHALL retornar uma string no formato `relatorios/<safe_name>_<timestamp>.md`.
+2. WHEN `file_path` contém separadores `/` ou `\`, THE `Report_Name_Generator` SHALL substituir cada separador pelo caractere `_` no `safe_name`.
+3. WHEN `file_path` contém o caractere `.`, THE `Report_Name_Generator` SHALL substituir cada `.` pelo caractere `_` no `safe_name`.
+4. WHEN `generate_report_name(file_path)` é chamado, THE `Report_Name_Generator` SHALL incluir um `timestamp` no formato `YYYYMMDD_HHMMSS` no nome do arquivo gerado.
+5. WHEN `generate_report_name(file_path)` é chamado duas vezes com o mesmo `file_path` em instantes distintos, THE `Report_Name_Generator` SHALL retornar nomes de arquivo diferentes.
+
+---
+
+### Requisito 2: Criação Automática do Diretório de Relatórios
+
+**User Story:** Como desenvolvedor, quero que a pasta `relatorios/` seja criada automaticamente, para que eu não precise configurar o ambiente manualmente antes de executar a análise.
+
+#### Critérios de Aceite
+
+1. WHEN `save_report(content, file_path)` é chamado e o diretório `relatorios/` não existe, THE `Report_Saver` SHALL criar o diretório `relatorios/` antes de salvar o arquivo.
+2. WHEN `save_report(content, file_path)` é chamado e o diretório `relatorios/` já existe, THE `Report_Saver` SHALL prosseguir com o salvamento sem lançar exceção.
+
+---
+
+### Requisito 3: Salvamento do Relatório em Markdown
+
+**User Story:** Como desenvolvedor, quero que o relatório seja salvo como arquivo `.md` com encoding UTF-8, para que caracteres especiais do português sejam preservados corretamente.
+
+#### Critérios de Aceite
+
+1. WHEN `save_report(content, file_path)` é chamado com um `content` válido, THE `Report_Saver` SHALL criar um arquivo `.md` em `relatorios/` com o conteúdo exato recebido.
+2. WHEN o arquivo de relatório é escrito, THE `Report_Saver` SHALL usar encoding `utf-8` na operação de escrita.
+3. WHEN `save_report(content, file_path)` é chamado com `content` contendo caracteres especiais (acentos, cedilha), THE `Report_Saver` SHALL preservar esses caracteres no arquivo salvo.
+4. WHEN `save_report(content, file_path)` é chamado com `MOCK_CONTENT` como `content`, THE `Report_Saver` SHALL salvar o arquivo sem depender de nenhum outro módulo do KiroSonar.
+
+---
+
+### Requisito 4: Retorno do Caminho Absoluto
+
+**User Story:** Como desenvolvedor, quero que `save_report()` retorne o caminho absoluto do relatório salvo, para que o módulo orquestrador (`cli.py`) possa exibir ou referenciar o arquivo gerado.
+
+#### Critérios de Aceite
+
+1. WHEN `save_report(content, file_path)` é executado com sucesso, THE `Report_Saver` SHALL retornar o caminho absoluto do arquivo de relatório criado.
+2. WHEN o caminho retornado por `save_report()` é verificado, THE `Report_Saver` SHALL retornar um caminho que aponta para um arquivo existente no sistema de arquivos.
+
+---
+
+### Requisito 5: Unicidade dos Relatórios
+
+**User Story:** Como desenvolvedor, quero que relatórios de arquivos diferentes não colidam entre si, para que nenhum relatório seja sobrescrito acidentalmente.
+
+#### Critérios de Aceite
+
+1. WHEN `save_report()` é chamado com dois `file_path` distintos, THE `Report_Saver` SHALL gerar nomes de arquivo diferentes para cada relatório.
+2. WHEN `save_report()` é chamado múltiplas vezes com o mesmo `file_path`, THE `Report_Saver` SHALL gerar nomes de arquivo distintos a cada chamada, garantidos pelo `timestamp`.
+
+---
+
+### Requisito 6: Feedback no Terminal
+
+**User Story:** Como desenvolvedor, quero ver no terminal o caminho do relatório salvo, para que eu saiba onde encontrar o arquivo gerado após a análise.
+
+#### Critérios de Aceite
+
+1. WHEN `save_report(content, file_path)` é executado com sucesso, THE `Report_Saver` SHALL imprimir o caminho absoluto do relatório salvo na saída padrão (`stdout`).

--- a/.kiro/specs/report-module/tasks.md
+++ b/.kiro/specs/report-module/tasks.md
@@ -1,0 +1,104 @@
+# Plano de Implementação: report-module
+
+## Visão Geral
+
+Implementação do módulo `report.py` do KiroSonar, responsável por gerar nomes únicos de relatório e persistir conteúdo Markdown em `relatorios/`. O módulo usa apenas Standard Library Python e é completamente independente dos demais módulos do projeto.
+
+## Tasks
+
+- [ ] 1. Implementar `generate_report_name` em `backend/src/report.py`
+  - Adicionar a constante `MOCK_CONTENT` com string Markdown fixa para testes independentes
+  - Implementar sanitização de `file_path` substituindo `/`, `\` e `.` por `_` → `safe_name`
+  - Capturar timestamp com `datetime.now().strftime("%Y%m%d_%H%M%S")`
+  - Retornar `os.path.join("relatorios", f"{safe_name}_{timestamp}.md")`
+  - Adicionar type hints e docstring completa
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+- [ ] 2. Implementar `save_report` em `backend/src/report.py`
+  - [ ] 2.1 Implementar corpo da função `save_report`
+    - Chamar `generate_report_name(file_path)` para obter `report_name`
+    - Criar diretório com `os.makedirs(os.path.dirname(report_name), exist_ok=True)`
+    - Escrever `content` no arquivo com `open(..., "w", encoding="utf-8")`
+    - Imprimir caminho absoluto em `stdout` via `print()`
+    - Retornar `os.path.abspath(report_name)`
+    - Adicionar type hints e docstring completa
+    - _Requirements: 2.1, 2.2, 3.1, 3.2, 3.4, 4.1, 4.2, 6.1_
+
+  - [ ]* 2.2 Escrever testes unitários para `generate_report_name`
+    - Testar exemplo concreto: `"src/app.py"` → prefixo `relatorios/`, sufixo `.md`, `safe_name` sem `/` nem `.`
+    - Testar `file_path` com separador Windows `\`
+    - Testar `file_path` vazio `""` (comportamento definido, sem exceção)
+    - Usar `monkeypatch` para fixar `datetime.now()` e verificar formato do timestamp
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+  - [ ]* 2.3 Escrever testes unitários para `save_report`
+    - Testar criação do arquivo com `MOCK_CONTENT` usando `tmp_path`
+    - Testar que `relatorios/` já existente não lança exceção (idempotência)
+    - Testar `content` vazio `""` cria arquivo sem erro
+    - Testar que o retorno é caminho absoluto apontando para arquivo existente
+    - Testar que `stdout` contém o caminho absoluto (capturar com `capsys`)
+    - _Requirements: 2.1, 2.2, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 5.1, 5.2, 6.1_
+
+- [ ] 3. Checkpoint — Garantir que os testes unitários passam
+  - Garantir que todos os testes passam, perguntar ao usuário se houver dúvidas.
+
+- [ ] 4. Escrever testes de propriedade com Hypothesis em `backend/tests/test_report.py`
+  - [ ]* 4.1 Escrever teste de propriedade para Property 1: Formato do nome gerado
+    - `@given(st.text(min_size=1))` — verificar prefixo `"relatorios/"`, sufixo `".md"` e regex `\d{8}_\d{6}` no resultado
+    - Tag: `# Feature: report-module, Property 1: Formato do nome gerado`
+    - `@settings(max_examples=100)`
+    - **Property 1: Formato do nome gerado**
+    - **Validates: Requirements 1.1, 1.4**
+
+  - [ ]* 4.2 Escrever teste de propriedade para Property 2: Sanitização do safe_name
+    - `@given(st.text())` — verificar ausência de `/`, `\` e `.` na parte `safe_name` do resultado
+    - Tag: `# Feature: report-module, Property 2: Sanitização do safe_name`
+    - `@settings(max_examples=100)`
+    - **Property 2: Sanitização do safe_name**
+    - **Validates: Requirements 1.2, 1.3**
+
+  - [ ]* 4.3 Escrever teste de propriedade para Property 3: Diretório criado automaticamente
+    - `@given(st.text(), st.text(min_size=1))` com `tmp_path` — verificar que `relatorios/` existe após `save_report`
+    - Tag: `# Feature: report-module, Property 3: Diretório criado automaticamente`
+    - `@settings(max_examples=100)`
+    - **Property 3: Diretório criado automaticamente**
+    - **Validates: Requirements 2.1, 2.2**
+
+  - [ ]* 4.4 Escrever teste de propriedade para Property 4: Round-trip de conteúdo com Unicode
+    - `@given(st.text())` com `tmp_path` — escrever e ler o arquivo, comparar conteúdo byte a byte
+    - Tag: `# Feature: report-module, Property 4: Round-trip de conteúdo com Unicode`
+    - `@settings(max_examples=100)`
+    - **Property 4: Round-trip de conteúdo com Unicode**
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+
+  - [ ]* 4.5 Escrever teste de propriedade para Property 5: Retorno é caminho absoluto existente
+    - `@given(st.text(), st.text(min_size=1))` com `tmp_path` — verificar `os.path.isabs` e `os.path.exists`
+    - Tag: `# Feature: report-module, Property 5: Retorno é caminho absoluto existente`
+    - `@settings(max_examples=100)`
+    - **Property 5: Retorno é caminho absoluto existente**
+    - **Validates: Requirements 4.1, 4.2**
+
+  - [ ]* 4.6 Escrever teste de propriedade para Property 6: file_paths distintos geram nomes distintos
+    - `@given(st.text(), st.text())` com `assume(fp1 != fp2)` — verificar que os `safe_name` diferem
+    - Tag: `# Feature: report-module, Property 6: file_paths distintos geram nomes distintos`
+    - `@settings(max_examples=100)`
+    - **Property 6: file_paths distintos geram nomes distintos**
+    - **Validates: Requirements 5.1**
+
+  - [ ]* 4.7 Escrever teste de propriedade para Property 7: stdout contém o caminho absoluto
+    - `@given(st.text(), st.text(min_size=1))` com `tmp_path` e `capsys` — verificar que `stdout` contém o caminho retornado
+    - Tag: `# Feature: report-module, Property 7: stdout contém o caminho absoluto`
+    - `@settings(max_examples=100)`
+    - **Property 7: stdout contém o caminho absoluto**
+    - **Validates: Requirements 6.1**
+
+- [ ] 5. Checkpoint final — Garantir que todos os testes passam
+  - Garantir que todos os testes unitários e de propriedade passam, perguntar ao usuário se houver dúvidas.
+
+## Notas
+
+- Tasks marcadas com `*` são opcionais e podem ser puladas para um MVP mais rápido
+- Todos os testes de I/O devem usar `tmp_path` do pytest para isolamento do sistema de arquivos real
+- O módulo não deve importar nenhum outro módulo interno do KiroSonar
+- `datetime.now()` pode ser mockado com `monkeypatch` para testes de unicidade temporal
+- Testes de propriedade requerem `hypothesis` instalado: `pip install hypothesis`


### PR DESCRIPTION
## Descrição

Adiciona o spec completo para implementação do módulo \eport.py\ (TASK-04).

## Documentos incluídos

- **requirements.md** — 6 requisitos com critérios de aceite no padrão EARS/INCOSE
- **design.md** — arquitetura, interfaces das funções, modelos de dados, 7 propriedades de corretude e estratégia de testes com Hypothesis
- **tasks.md** — plano de implementação com tasks rastreadas aos requisitos

## Escopo

Módulo \ackend/src/report.py\ responsável por:
- Gerar nome único de relatório com timestamp (\generate_report_name\)
- Persistir relatório Markdown em \elatorios/\ com encoding UTF-8 (\save_report\)

## Checklist

- [x] requirements.md criado
- [x] design.md criado
- [x] tasks.md criado
- [ ] Implementação pendente