### PR TITLE
docs: spec do módulo autofix (issue-65)

### DIFF
--- a/.kiro/specs/autofix-module/.config.kiro
+++ b/.kiro/specs/autofix-module/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "f3a1bc92-7d4e-4c8b-a5f0-2e9d6b3c1a47", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/autofix-module/design.md
+++ b/.kiro/specs/autofix-module/design.md
@@ -1,0 +1,209 @@
+# Design Técnico: autofix-module
+
+## Visão Geral
+
+O `autofix.py` é um módulo utilitário do KiroSonar responsável por extrair o código refatorado da resposta da LLM e aplicá-lo ao arquivo original com confirmação explícita do usuário. Ele é completamente independente dos demais módulos — recebe dados prontos do orquestrador (`cli.py`) e não consome nenhuma outra dependência interna do projeto.
+
+O módulo expõe duas funções públicas:
+
+- `extract_refactored_code(ai_response)` — extrai o conteúdo entre as tags `[START]` e `[END]` via Regex.
+- `apply_fix(ai_response, file_path)` — orquestra o preview, a confirmação interativa e a sobrescrita do arquivo.
+
+Restrições técnicas:
+- Apenas Standard Library Python (`re`, `os`)
+- Python 3.11+
+- PEP 8, Type Hinting obrigatório, Docstrings em todas as funções
+- Encoding UTF-8 em todas as operações de escrita
+
+---
+
+## Arquitetura
+
+O módulo segue uma arquitetura de funções puras e procedimentos simples, sem estado global nem classes. O fluxo de execução é linear:
+
+```mermaid
+sequenceDiagram
+    participant CLI as cli.py
+    participant A as autofix.py
+    participant U as Usuário (stdin)
+    participant FS as Sistema de Arquivos
+
+    CLI->>A: apply_fix(ai_response, file_path)
+    A->>A: extract_refactored_code(ai_response)
+    alt Tags [START]/[END] não encontradas
+        A-->>CLI: False
+    else Tags encontradas
+        A->>U: exibe file_path + preview (20 linhas)
+        A->>U: "Deseja aplicar o fix em '<file_path>'? (s/n): "
+        U-->>A: input do usuário
+        alt input == 's' ou 'S'
+            A->>FS: open(file_path, "w", encoding="utf-8")
+            FS-->>A: arquivo sobrescrito
+            A->>U: mensagem de confirmação
+            A-->>CLI: True
+        else qualquer outra entrada
+            A->>U: "Fix não aplicado."
+            A-->>CLI: False
+        end
+    end
+```
+
+### Decisões de Design
+
+1. **Separação de responsabilidades**: `extract_refactored_code()` é uma função pura (sem efeitos colaterais) que pode ser testada isoladamente. `apply_fix()` orquestra os efeitos colaterais (I/O de terminal e arquivo).
+2. **Regex com `re.DOTALL`**: a flag `DOTALL` é obrigatória para capturar código com múltiplas linhas entre as tags. O padrão `r'\[START\]\s*\n(.*?)\n\s*\[END\]'` usa `.*?` (non-greedy) para capturar apenas o primeiro bloco de código.
+3. **Preview limitado a 20 linhas**: evita poluição do terminal para arquivos grandes, mantendo o feedback útil sem sobrecarregar o desenvolvedor.
+4. **Confirmação case-insensitive**: aceitar `s` e `S` melhora a usabilidade sem adicionar complexidade.
+5. **Sem rollback automático**: conforme o PRD (seção 11), o mecanismo de rollback é responsabilidade do desenvolvedor via `git checkout`. O módulo não implementa backup.
+
+---
+
+## Componentes e Interfaces
+
+### `extract_refactored_code(ai_response: str) -> str | None`
+
+Responsabilidade: parsear a resposta da LLM e retornar o código refatorado ou `None`.
+
+```
+Entrada : ai_response → str  (Markdown completo retornado pela LLM)
+Saída   : str | None         (código extraído ou None se tags ausentes)
+```
+
+Algoritmo:
+1. Aplicar `re.search(r'\[START\]\s*\n(.*?)\n\s*\[END\]', ai_response, re.DOTALL)`
+2. Se `match`: retornar `match.group(1)`
+3. Se não `match`: retornar `None`
+
+### `apply_fix(ai_response: str, file_path: str) -> bool`
+
+Responsabilidade: orquestrar extração, preview, confirmação e sobrescrita.
+
+```
+Entrada : ai_response → str  (Markdown completo retornado pela LLM)
+          file_path   → str  (caminho do arquivo original a ser sobrescrito)
+Saída   : bool               (True se aplicado, False caso contrário)
+```
+
+Algoritmo:
+1. Chamar `extract_refactored_code(ai_response)` → `code`
+2. Se `code is None`: imprimir aviso, retornar `False`
+3. Gerar `preview = "\n".join(code.splitlines()[:20])`
+4. Imprimir `file_path` e `preview` no terminal
+5. Chamar `input(f"Deseja aplicar o fix em '{file_path}'? (s/n): ")` → `answer`
+6. Se `answer.strip().lower() != "s"`: imprimir "Fix não aplicado.", retornar `False`
+7. Abrir `file_path` em modo escrita com `encoding="utf-8"`, escrever `code`
+8. Imprimir mensagem de confirmação, retornar `True`
+
+---
+
+## Modelos de Dados
+
+O módulo não define classes nem estruturas de dados próprias. Os tipos envolvidos são primitivos Python:
+
+| Símbolo | Tipo | Descrição |
+|---|---|---|
+| `ai_response` | `str` | Resposta Markdown completa da LLM, podendo conter `[START]...[END]` |
+| `file_path` | `str` | Caminho do arquivo de código-fonte a ser sobrescrito |
+| `refactored_code` | `str \| None` | Código extraído entre as tags, ou `None` se ausente |
+| `preview` | `str` | Primeiras 20 linhas do `refactored_code` para exibição no terminal |
+| `MOCK_AI_RESPONSE` | `str` | Constante Markdown para testes independentes da LLM |
+
+### Padrão Regex
+
+```python
+PATTERN = r'\[START\]\s*\n(.*?)\n\s*\[END\]'
+FLAGS    = re.DOTALL
+```
+
+- `\[START\]` — escapa os colchetes literais
+- `\s*\n` — permite espaços opcionais antes da quebra de linha após a tag
+- `(.*?)` — captura o código (non-greedy, grupo 1)
+- `\n\s*\[END\]` — quebra de linha antes da tag de fechamento, com espaços opcionais
+
+---
+
+## Propriedades de Corretude
+
+### Propriedade 1: Extração correta com tags presentes
+
+*Para qualquer* `ai_response` que contenha `[START]\n<código>\n[END]`, `extract_refactored_code(ai_response)` deve retornar exatamente o conteúdo entre as tags, sem incluir as próprias tags.
+
+**Validates: Requirements 1.1, 1.3**
+
+---
+
+### Propriedade 2: Retorno None sem tags
+
+*Para qualquer* `ai_response` que não contenha simultaneamente `[START]` e `[END]`, `extract_refactored_code(ai_response)` deve retornar `None`.
+
+**Validates: Requirements 1.2**
+
+---
+
+### Propriedade 3: apply_fix retorna False sem código refatorado
+
+*Para qualquer* `ai_response` sem as tags `[START]`/`[END]` e qualquer `file_path`, `apply_fix(ai_response, file_path)` deve retornar `False` sem modificar nenhum arquivo no sistema de arquivos.
+
+**Validates: Requirements 3.5, 5.3**
+
+---
+
+### Propriedade 4: Arquivo não modificado sem confirmação
+
+*Para qualquer* `ai_response` com código refatorado e qualquer `file_path`, se o usuário fornecer qualquer entrada diferente de `s`/`S`, o arquivo em `file_path` não deve ser modificado e `apply_fix()` deve retornar `False`.
+
+**Validates: Requirements 3.4, 5.2**
+
+---
+
+### Propriedade 5: Round-trip de conteúdo com confirmação
+
+*Para qualquer* `refactored_code` válido, após `apply_fix()` com confirmação `s`, a leitura do arquivo em `file_path` com `encoding="utf-8"` deve retornar exatamente o `refactored_code` extraído.
+
+**Validates: Requirements 4.1, 4.2**
+
+---
+
+## Tratamento de Erros
+
+| Cenário | Comportamento esperado |
+|---|---|
+| `ai_response` sem tags `[START]`/`[END]` | `extract_refactored_code()` retorna `None`; `apply_fix()` imprime aviso e retorna `False` |
+| `file_path` inexistente com confirmação `s` | `FileNotFoundError` propagado naturalmente pelo `open()` — não tratado no módulo |
+| Sem permissão de escrita em `file_path` | `PermissionError` propagado ao orquestrador (`cli.py`) |
+| Usuário digita entrada vazia no prompt | `answer.strip()` resulta em `""`, diferente de `"s"` — fix não aplicado, retorna `False` |
+
+A estratégia de não capturar exceções de I/O é intencional: erros de permissão ou arquivo inexistente devem ser propagados ao orquestrador, que tem o contexto para exibir mensagens de erro ao usuário.
+
+---
+
+## Estratégia de Testes
+
+### Arquivo de testes
+
+`backend/tests/test_autofix.py`
+
+### Testes Unitários para `extract_refactored_code`
+
+- Exemplo concreto: `MOCK_AI_RESPONSE` → retorna o código correto
+- Tags presentes com código multilinhas → retorna todas as linhas
+- Sem tags → retorna `None`
+- Tags presentes mas código vazio entre elas → retorna string vazia
+- Apenas `[START]` sem `[END]` → retorna `None`
+
+### Testes Unitários para `apply_fix`
+
+Todos os testes de I/O devem usar `tmp_path` (fixture do pytest) para isolamento.
+
+- Sem código refatorado → retorna `False`, arquivo não criado/modificado
+- Com código, usuário digita `n` → retorna `False`, arquivo não modificado (mock de `input`)
+- Com código, usuário digita `s` → retorna `True`, arquivo sobrescrito com conteúdo correto
+- Com código, usuário digita `S` → retorna `True` (case-insensitive)
+- Com código, usuário digita entrada vazia → retorna `False`
+- Preview limitado a 20 linhas para código com mais de 20 linhas (capturar `stdout`)
+
+### Isolamento
+
+- Usar `monkeypatch` para mockar `builtins.input` nos testes de `apply_fix`
+- Usar `tmp_path` para todos os testes que envolvem escrita de arquivo
+- Usar `capsys` para verificar mensagens exibidas no terminal

--- a/.kiro/specs/autofix-module/requirements.md
+++ b/.kiro/specs/autofix-module/requirements.md
@@ -1,0 +1,95 @@
+# Documento de Requisitos
+
+## Introdução
+
+O módulo `autofix.py` é responsável por extrair o código refatorado da resposta da LLM e aplicá-lo ao arquivo original com confirmação explícita do usuário. Ele recebe a resposta completa da IA como string Markdown, busca o conteúdo entre as tags `[START]` e `[END]` via Regex, exibe um preview no terminal e sobrescreve o arquivo somente após o usuário confirmar com `s` ou `S`. O módulo é independente dos demais módulos do KiroSonar e pode ser testado isoladamente com conteúdo mock.
+
+## Glossário
+
+- **AutoFix_Module**: O módulo `src/autofix.py` responsável por extrair e aplicar código refatorado.
+- **Code_Extractor**: A função `extract_refactored_code()` que parseia a resposta da LLM.
+- **Fix_Applier**: A função `apply_fix()` que orquestra o preview, a confirmação e a sobrescrita do arquivo.
+- **ai_response**: String Markdown completa retornada pela LLM, podendo conter as tags `[START]` e `[END]`.
+- **file_path**: Caminho do arquivo de código-fonte original a ser sobrescrito.
+- **refactored_code**: Conteúdo extraído entre as tags `[START]` e `[END]` da resposta da LLM.
+- **preview**: As primeiras 20 linhas do `refactored_code`, exibidas no terminal antes da confirmação.
+- **MOCK_AI_RESPONSE**: String Markdown fixa usada para testes independentes da LLM.
+
+---
+
+## Requisitos
+
+### Requisito 1: Extração do Código Refatorado
+
+**User Story:** Como desenvolvedor, quero que o sistema extraia automaticamente o código refatorado da resposta da IA, para que eu não precise copiar e colar manualmente o código sugerido.
+
+#### Critérios de Aceite
+
+1. WHEN `extract_refactored_code(ai_response)` é chamado com uma string contendo `[START]` e `[END]`, THE `Code_Extractor` SHALL retornar o conteúdo entre as tags como string.
+2. WHEN `extract_refactored_code(ai_response)` é chamado com uma string que não contém as tags `[START]` e `[END]`, THE `Code_Extractor` SHALL retornar `None`.
+3. WHEN o conteúdo entre `[START]` e `[END]` contém múltiplas linhas, THE `Code_Extractor` SHALL capturar todas as linhas corretamente usando a flag `re.DOTALL`.
+4. WHEN há espaços ou quebras de linha entre a tag `[START]` e o início do código, THE `Code_Extractor` SHALL ignorá-los e retornar apenas o código.
+5. WHEN `extract_refactored_code(ai_response)` é chamado com `MOCK_AI_RESPONSE`, THE `Code_Extractor` SHALL retornar o código refatorado sem depender de nenhum outro módulo do KiroSonar.
+
+---
+
+### Requisito 2: Exibição do Preview no Terminal
+
+**User Story:** Como desenvolvedor, quero visualizar um preview do código refatorado antes de decidir aplicá-lo, para que eu possa avaliar a qualidade da sugestão da IA.
+
+#### Critérios de Aceite
+
+1. WHEN `apply_fix(ai_response, file_path)` é chamado e há código refatorado, THE `Fix_Applier` SHALL exibir o caminho do arquivo que será alterado no terminal.
+2. WHEN `apply_fix(ai_response, file_path)` é chamado e há código refatorado, THE `Fix_Applier` SHALL exibir no máximo as primeiras 20 linhas do código refatorado como preview.
+3. WHEN o código refatorado tem menos de 20 linhas, THE `Fix_Applier` SHALL exibir todas as linhas disponíveis no preview.
+4. WHEN `apply_fix(ai_response, file_path)` é chamado e não há código refatorado, THE `Fix_Applier` SHALL exibir uma mensagem informando que nenhum código refatorado foi encontrado.
+
+---
+
+### Requisito 3: Confirmação Interativa do Usuário
+
+**User Story:** Como desenvolvedor, quero ser perguntado explicitamente antes de qualquer sobrescrita de arquivo, para que eu tenha controle total sobre quais alterações são aplicadas ao meu código.
+
+#### Critérios de Aceite
+
+1. WHEN há código refatorado disponível, THE `Fix_Applier` SHALL exibir o prompt `Deseja aplicar o fix em '<file_path>'? (s/n): ` antes de qualquer operação de escrita.
+2. WHEN o usuário digita `s`, THE `Fix_Applier` SHALL prosseguir com a sobrescrita do arquivo.
+3. WHEN o usuário digita `S`, THE `Fix_Applier` SHALL prosseguir com a sobrescrita do arquivo.
+4. WHEN o usuário digita qualquer entrada diferente de `s` ou `S`, THE `Fix_Applier` SHALL não sobrescrever o arquivo.
+5. WHEN não há código refatorado, THE `Fix_Applier` SHALL retornar `False` sem exibir o prompt de confirmação.
+
+---
+
+### Requisito 4: Sobrescrita do Arquivo com Encoding UTF-8
+
+**User Story:** Como desenvolvedor, quero que o arquivo seja sobrescrito com o código refatorado usando encoding UTF-8, para que caracteres especiais do português sejam preservados corretamente.
+
+#### Critérios de Aceite
+
+1. WHEN o usuário confirma com `s` ou `S`, THE `Fix_Applier` SHALL sobrescrever o arquivo em `file_path` com o `refactored_code` extraído.
+2. WHEN o arquivo é sobrescrito, THE `Fix_Applier` SHALL usar encoding `utf-8` na operação de escrita.
+3. WHEN o arquivo é sobrescrito com sucesso, THE `Fix_Applier` SHALL exibir uma mensagem de confirmação no terminal.
+4. WHEN o arquivo é sobrescrito com sucesso, THE `Fix_Applier` SHALL retornar `True`.
+
+---
+
+### Requisito 5: Retorno de Status da Operação
+
+**User Story:** Como desenvolvedor, quero que `apply_fix()` retorne um booleano indicando se o fix foi aplicado, para que o orquestrador (`cli.py`) possa registrar o resultado da operação.
+
+#### Critérios de Aceite
+
+1. WHEN `apply_fix()` sobrescreve o arquivo com sucesso, THE `Fix_Applier` SHALL retornar `True`.
+2. WHEN o usuário recusa a aplicação digitando qualquer entrada diferente de `s`/`S`, THE `Fix_Applier` SHALL retornar `False`.
+3. WHEN não há código refatorado na resposta da IA, THE `Fix_Applier` SHALL retornar `False`.
+
+---
+
+### Requisito 6: Independência de Módulos
+
+**User Story:** Como desenvolvedor, quero que o módulo `autofix.py` funcione de forma independente, para que eu possa testá-lo e depurá-lo sem precisar dos demais módulos do KiroSonar.
+
+#### Critérios de Aceite
+
+1. WHEN `autofix.py` é executado com `MOCK_AI_RESPONSE`, THE `AutoFix_Module` SHALL funcionar corretamente sem importar nenhum outro módulo interno do KiroSonar.
+2. WHEN `autofix.py` é importado, THE `AutoFix_Module` SHALL depender apenas da Standard Library Python (`re`, `os`).

--- a/.kiro/specs/autofix-module/tasks.md
+++ b/.kiro/specs/autofix-module/tasks.md
@@ -1,0 +1,64 @@
+# Plano de Implementação: autofix-module
+
+## Visão Geral
+
+Implementação do módulo `autofix.py` do KiroSonar, responsável por extrair o código refatorado da resposta da LLM e aplicá-lo ao arquivo original com confirmação explícita do usuário. O módulo usa apenas Standard Library Python e é completamente independente dos demais módulos do projeto.
+
+O arquivo `backend/src/autofix.py` já possui uma implementação inicial. As tasks abaixo cobrem a verificação, ajustes necessários e a escrita dos testes.
+
+## Tasks
+
+- [ ] 1. Verificar e validar `extract_refactored_code` em `backend/src/autofix.py`
+  - Confirmar que o Regex `r'\[START\]\s*\n(.*?)\n\s*\[END\]'` está aplicado com a flag `re.DOTALL`
+  - Confirmar que retorna `match.group(1)` quando as tags são encontradas
+  - Confirmar que retorna `None` quando as tags estão ausentes
+  - Confirmar type hints (`ai_response: str`) e retorno (`str | None`)
+  - Confirmar docstring completa com Args e Returns
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+- [ ] 2. Verificar e validar `apply_fix` em `backend/src/autofix.py`
+  - Confirmar que chama `extract_refactored_code()` e retorna `False` se `None`
+  - Confirmar que exibe o `file_path` e o preview das primeiras 20 linhas via `code.splitlines()[:20]`
+  - Confirmar que exibe o prompt `Deseja aplicar o fix em '<file_path>'? (s/n): `
+  - Confirmar que aceita `s` e `S` (case-insensitive via `.strip().lower()`)
+  - Confirmar que sobrescreve o arquivo com `open(file_path, "w", encoding="utf-8")`
+  - Confirmar que retorna `True` após sobrescrita e `False` em caso de recusa ou ausência de código
+  - Confirmar type hints e docstring completa
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, 5.1, 5.2, 5.3_
+
+- [ ] 3. Adicionar `MOCK_AI_RESPONSE` em `backend/src/autofix.py`
+  - Adicionar a constante `MOCK_AI_RESPONSE` com a string Markdown definida na TASK-05
+  - Garantir que o mock contém as tags `[START]` e `[END]` com código válido
+  - _Requirements: 1.5, 6.1_
+
+- [ ] 4. Escrever testes unitários para `extract_refactored_code` em `backend/tests/test_autofix.py`
+  - [ ]* 4.1 Testar extração com `MOCK_AI_RESPONSE` → retorna o código correto
+  - [ ]* 4.2 Testar extração com código multilinhas → retorna todas as linhas
+  - [ ]* 4.3 Testar sem tags → retorna `None`
+  - [ ]* 4.4 Testar apenas `[START]` sem `[END]` → retorna `None`
+  - [ ]* 4.5 Testar código vazio entre as tags → retorna string vazia ou `None` conforme o Regex
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+- [ ] 5. Escrever testes unitários para `apply_fix` em `backend/tests/test_autofix.py`
+  - [ ]* 5.1 Testar sem código refatorado → retorna `False`, nenhum arquivo criado (`tmp_path`)
+  - [ ]* 5.2 Testar com código, usuário digita `n` → retorna `False`, arquivo não modificado (mock `input`)
+  - [ ]* 5.3 Testar com código, usuário digita `s` → retorna `True`, arquivo sobrescrito com conteúdo correto
+  - [ ]* 5.4 Testar com código, usuário digita `S` → retorna `True` (case-insensitive)
+  - [ ]* 5.5 Testar com código, usuário digita entrada vazia → retorna `False`
+  - [ ]* 5.6 Testar preview limitado a 20 linhas para código com mais de 20 linhas (capturar `stdout` com `capsys`)
+  - [ ]* 5.7 Testar que a mensagem de aviso é exibida quando não há código refatorado (`capsys`)
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, 5.1, 5.2, 5.3_
+
+- [ ] 6. Checkpoint final — Garantir que todos os testes passam
+  - Executar `pytest backend/tests/test_autofix.py -v` e confirmar que todos os testes passam
+  - Garantir que o módulo segue PEP 8 (sem imports desnecessários, indentação correta)
+  - Perguntar ao usuário se houver dúvidas antes de encerrar
+
+## Notas
+
+- Tasks marcadas com `*` são opcionais e podem ser puladas para um MVP mais rápido
+- Todos os testes de I/O devem usar `tmp_path` do pytest para isolamento do sistema de arquivos real
+- Usar `monkeypatch` para mockar `builtins.input` nos testes de `apply_fix`
+- Usar `capsys` para verificar mensagens exibidas no terminal
+- O módulo não deve importar nenhum outro módulo interno do KiroSonar
+- A implementação atual em `autofix.py` já cobre os requisitos principais — as tasks 1 e 2 são de verificação/validação


### PR DESCRIPTION
## Descrição\n\nAdiciona o spec completo do módulo utofix.py referente à TASK-05.\n\n## Alterações\n\n- .kiro/specs/autofix-module/requirements.md — 6 requisitos cobrindo extração, preview, confirmação interativa, sobrescrita UTF-8, retorno de status e independência de módulos\n- .kiro/specs/autofix-module/design.md — arquitetura, diagrama de sequência, interfaces, padrão Regex, propriedades de corretude e estratégia de testes\n- .kiro/specs/autofix-module/tasks.md — 6 tasks: validação da implementação existente, testes unitários e checkpoint final\n\n## Issue\n\nFecha #65