### PR TITLE
feat: adiciona suporte a Docker para execução do KiroSonar

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,12 @@ docker run --rm -it -v "$(pwd):/project" -w /project kirosonar:latest analyze --
 docker run --rm -v "$(pwd):/project" -w /project kirosonar:latest report
 ```
 
-> O `-v "$(pwd):/project"` monta o diretório atual dentro do container, e o `-w /project` define como diretório de trabalho. O `-it` permite a interação com o auto-fix. Por padrão, o mock da LLM está ativado (`KIROSONAR_MOCK=1`). Para usar a LLM real, passe `-e KIROSONAR_MOCK=0` e monte o binário `kiro-cli` no container.
+> **Flags importantes:**
+> - `-it` é obrigatório para os comandos de análise. Sem ele, o prompt interativo do auto-fix ("Deseja aplicar o fix? s/n") não funciona e o container encerra com erro `EOFError`. Para comandos não-interativos como `report`, o `-it` é opcional.
+> - `-v "$(pwd):/project"` monta o diretório atual dentro do container.
+> - `-w /project` define o diretório de trabalho.
+>
+> Por padrão, o mock da LLM está ativado (`KIROSONAR_MOCK=1`). Para usar a LLM real, passe `-e KIROSONAR_MOCK=0` e monte o binário `kiro-cli` no container.
 
 ### Uso
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,30 @@ conda activate kirosonar
 pip install -e ".[dev]"
 ```
 
+### Usando com Docker (recomendado)
+
+Não precisa instalar Python, dependências ou configurar nada. Só precisa do Docker.
+
+```bash
+# Build da imagem (uma vez só)
+cd backend
+docker build -t kirosonar:latest .
+
+# Analisar um arquivo específico do seu projeto
+docker run --rm -it -v "$(pwd):/project" -w /project kirosonar:latest analyze --path src/meu_arquivo.js
+
+# Analisar arquivos alterados via git diff
+docker run --rm -it -v "$(pwd):/project" -w /project kirosonar:latest analyze
+
+# Usar regras customizadas
+docker run --rm -it -v "$(pwd):/project" -w /project kirosonar:latest analyze --rules regras_empresa.md
+
+# Listar relatórios gerados
+docker run --rm -v "$(pwd):/project" -w /project kirosonar:latest report
+```
+
+> O `-v "$(pwd):/project"` monta o diretório atual dentro do container, e o `-w /project` define como diretório de trabalho. O `-it` permite a interação com o auto-fix. Por padrão, o mock da LLM está ativado (`KIROSONAR_MOCK=1`). Para usar a LLM real, passe `-e KIROSONAR_MOCK=0` e monte o binário `kiro-cli` no container.
+
 ### Uso
 
 ```bash

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+.pytest_cache
+.ruff_cache
+.hypothesis
+*.egg-info
+.env
+.venv

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY pyproject.toml .
+COPY src/ src/
+COPY tests/ tests/
+
+RUN pip install --no-cache-dir -e .
+
+ENV KIROSONAR_MOCK=1
+ENV PYTHONPATH=/app
+
+ENTRYPOINT ["kirosonar"]
+CMD ["analyze", "--help"]


### PR DESCRIPTION
Adiciona Dockerfile e configuração Docker para permitir que o KiroSonar seja executado sem necessidade de instalar Python, dependências ou configurar ambiente local. O usuário só precisa do Docker instalado.

## O que foi feito

- Criado `backend/Dockerfile` baseado em `python:3.11-slim` com Git instalado, pronto para uso com `docker run`
- Criado `backend/.dockerignore` para manter o build limpo
- Atualizado `README.md` com seção "Usando com Docker (recomendado)" contendo exemplos de build e uso

## Como usar

```bash
cd backend
docker build -t kirosonar:latest .
docker run --rm -it -v "$(pwd):/project" -w /project kirosonar:latest analyze --path src/arquivo.js
```

O container roda com mock da LLM ativado por padrão (`KIROSONAR_MOCK=1`), permitindo uso imediato sem dependência do `kiro-cli`.
